### PR TITLE
Add toolbar tools for drawing and gates

### DIFF
--- a/LEARN-alpha/LEARN-alpha.csproj
+++ b/LEARN-alpha/LEARN-alpha.csproj
@@ -9,4 +9,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="Assets\*.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/LEARN-alpha/Learn.Designer.cs
+++ b/LEARN-alpha/Learn.Designer.cs
@@ -28,14 +28,131 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
+            toolPanel = new FlowLayoutPanel();
+            pointerButton = new Button();
+            penButton = new Button();
+            eraserButton = new Button();
+            andGateButton = new Button();
+            orGateButton = new Button();
+            notGateButton = new Button();
+            xorGateButton = new Button();
+            toolPanel.SuspendLayout();
             SuspendLayout();
-            // 
+            //
+            // toolPanel
+            //
+            toolPanel.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            toolPanel.AutoSize = true;
+            toolPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            toolPanel.BackColor = Color.FromArgb(245, 245, 245);
+            toolPanel.Controls.Add(pointerButton);
+            toolPanel.Controls.Add(penButton);
+            toolPanel.Controls.Add(eraserButton);
+            toolPanel.Controls.Add(andGateButton);
+            toolPanel.Controls.Add(orGateButton);
+            toolPanel.Controls.Add(notGateButton);
+            toolPanel.Controls.Add(xorGateButton);
+            toolPanel.FlowDirection = FlowDirection.LeftToRight;
+            toolPanel.Location = new Point(12, 12);
+            toolPanel.Margin = new Padding(4);
+            toolPanel.Name = "toolPanel";
+            toolPanel.Padding = new Padding(8, 6, 8, 6);
+            toolPanel.Size = new Size(667, 64);
+            toolPanel.TabIndex = 0;
+            toolPanel.WrapContents = false;
+            //
+            // pointerButton
+            //
+            pointerButton.BackColor = SystemColors.ControlLight;
+            pointerButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            pointerButton.Location = new Point(12, 9);
+            pointerButton.Margin = new Padding(4, 3, 4, 3);
+            pointerButton.Name = "pointerButton";
+            pointerButton.Size = new Size(90, 44);
+            pointerButton.TabIndex = 0;
+            pointerButton.Text = "포인터";
+            pointerButton.UseVisualStyleBackColor = false;
+            //
+            // penButton
+            //
+            penButton.BackColor = SystemColors.ControlLight;
+            penButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            penButton.Location = new Point(110, 9);
+            penButton.Margin = new Padding(4, 3, 4, 3);
+            penButton.Name = "penButton";
+            penButton.Size = new Size(90, 44);
+            penButton.TabIndex = 1;
+            penButton.Text = "펜";
+            penButton.UseVisualStyleBackColor = false;
+            //
+            // eraserButton
+            //
+            eraserButton.BackColor = SystemColors.ControlLight;
+            eraserButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            eraserButton.Location = new Point(208, 9);
+            eraserButton.Margin = new Padding(4, 3, 4, 3);
+            eraserButton.Name = "eraserButton";
+            eraserButton.Size = new Size(90, 44);
+            eraserButton.TabIndex = 2;
+            eraserButton.Text = "지우개";
+            eraserButton.UseVisualStyleBackColor = false;
+            //
+            // andGateButton
+            //
+            andGateButton.BackColor = SystemColors.ControlLight;
+            andGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            andGateButton.Location = new Point(306, 9);
+            andGateButton.Margin = new Padding(4, 3, 4, 3);
+            andGateButton.Name = "andGateButton";
+            andGateButton.Size = new Size(90, 44);
+            andGateButton.TabIndex = 3;
+            andGateButton.Text = "AND";
+            andGateButton.UseVisualStyleBackColor = false;
+            //
+            // orGateButton
+            //
+            orGateButton.BackColor = SystemColors.ControlLight;
+            orGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            orGateButton.Location = new Point(404, 9);
+            orGateButton.Margin = new Padding(4, 3, 4, 3);
+            orGateButton.Name = "orGateButton";
+            orGateButton.Size = new Size(90, 44);
+            orGateButton.TabIndex = 4;
+            orGateButton.Text = "OR";
+            orGateButton.UseVisualStyleBackColor = false;
+            //
+            // notGateButton
+            //
+            notGateButton.BackColor = SystemColors.ControlLight;
+            notGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            notGateButton.Location = new Point(502, 9);
+            notGateButton.Margin = new Padding(4, 3, 4, 3);
+            notGateButton.Name = "notGateButton";
+            notGateButton.Size = new Size(90, 44);
+            notGateButton.TabIndex = 5;
+            notGateButton.Text = "NOT";
+            notGateButton.UseVisualStyleBackColor = false;
+            //
+            // xorGateButton
+            //
+            xorGateButton.BackColor = SystemColors.ControlLight;
+            xorGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            xorGateButton.Location = new Point(600, 9);
+            xorGateButton.Margin = new Padding(4, 3, 4, 3);
+            xorGateButton.Name = "xorGateButton";
+            xorGateButton.Size = new Size(90, 44);
+            xorGateButton.TabIndex = 6;
+            xorGateButton.Text = "XOR";
+            xorGateButton.UseVisualStyleBackColor = false;
+            //
             // Learn
-            // 
+            //
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1063, 610);
+            Controls.Add(toolPanel);
             DoubleBuffered = true;
             KeyPreview = true;
             Name = "Learn";
@@ -44,9 +161,21 @@
             MouseDown += OnMouseDown;
             MouseMove += OnMouseMove;
             MouseUp += OnMouseUp;
+            MouseLeave += OnMouseLeave;
+            toolPanel.ResumeLayout(false);
             ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
+
+        private FlowLayoutPanel toolPanel;
+        private Button pointerButton;
+        private Button penButton;
+        private Button eraserButton;
+        private Button andGateButton;
+        private Button orGateButton;
+        private Button notGateButton;
+        private Button xorGateButton;
     }
 }

--- a/LEARN-alpha/Learn.cs
+++ b/LEARN-alpha/Learn.cs
@@ -1,4 +1,7 @@
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
 
 namespace LEARN_alpha
 {
@@ -7,12 +10,55 @@ namespace LEARN_alpha
         public Learn()
         {
             InitializeComponent();
+            InitializeTools();
+        }
+
+        private enum ToolType
+        {
+            Pointer,
+            Pen,
+            Eraser,
+            GateAnd,
+            GateOr,
+            GateNot,
+            GateXor
+        }
+
+        private sealed class GateElement
+        {
+            public ToolType Type { get; }
+            public Bitmap Image { get; }
+            public Point Location { get; set; }
+            public Size Size => Image.Size;
+            public Rectangle Bounds => new Rectangle(Location, Size);
+
+            public GateElement(ToolType type, Bitmap image, Point location)
+            {
+                Type = type;
+                Image = image;
+                Location = location;
+            }
         }
 
         private readonly List<Point[]> segments = new List<Point[]>();
-        private bool isDragging = false;
-        private Point start;
-        private Point current;
+        private readonly List<GateElement> gates = new List<GateElement>();
+        private readonly Dictionary<ToolType, Bitmap> gateImages = new Dictionary<ToolType, Bitmap>();
+        private readonly Dictionary<ToolType, Button> toolButtons = new Dictionary<ToolType, Button>();
+
+        private ToolType currentTool = ToolType.Pointer;
+
+        private bool isDrawing = false;
+        private bool isErasing = false;
+        private Point drawingStart;
+        private Point drawingCurrent;
+
+        private GateElement? pointerGateSelection;
+        private Size pointerGateOffset;
+        private int pointerSegmentIndex = -1;
+        private Point[]? pointerSegmentOriginal;
+        private Point pointerDragStart;
+
+        private Point? gatePreviewLocation;
 
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
@@ -20,6 +66,9 @@ namespace LEARN_alpha
             if (e.KeyCode == Keys.C)
             {
                 segments.Clear();
+                gates.Clear();
+                ResetPointerState();
+                gatePreviewLocation = null;
                 Invalidate();
             }
         }
@@ -27,34 +76,80 @@ namespace LEARN_alpha
         private void OnMouseDown(object sender, MouseEventArgs e)
         {
             if (e.Button != MouseButtons.Left) { return; }
-            isDragging = true;
-            start = e.Location;
-            current = e.Location;
-            Capture = true;
-            Invalidate();
+
+            switch (currentTool)
+            {
+                case ToolType.Pen:
+                    isDrawing = true;
+                    drawingStart = e.Location;
+                    drawingCurrent = e.Location;
+                    Capture = true;
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    isErasing = true;
+                    EraseAt(e.Location);
+                    Capture = true;
+                    break;
+                case ToolType.Pointer:
+                    BeginPointerDrag(e.Location);
+                    break;
+                default:
+                    PlaceGate(e.Location);
+                    break;
+            }
         }
 
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
-            if (!isDragging) { return; }
-            current = e.Location;
-            Invalidate();
+            switch (currentTool)
+            {
+                case ToolType.Pen:
+                    if (!isDrawing) { return; }
+                    drawingCurrent = e.Location;
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    if (!isErasing) { return; }
+                    EraseAt(e.Location);
+                    break;
+                case ToolType.Pointer:
+                    UpdatePointerDrag(e.Location);
+                    break;
+                default:
+                    gatePreviewLocation = e.Location;
+                    Invalidate();
+                    break;
+            }
         }
 
         private void OnMouseUp(object sender, MouseEventArgs e)
         {
-            if (!isDragging || e.Button != MouseButtons.Left) { return; }
-            isDragging = false;
-            Capture = false;
+            if (e.Button != MouseButtons.Left) { return; }
 
-            bool preferHorizontalFirst = PreferHorizontalFirst(start, e.Location);
-
-            var trio = BuildOrthogonalPath(start, e.Location, preferHorizontalFirst);
-            if (trio != null)
+            switch (currentTool)
             {
-                segments.Add(trio);
+                case ToolType.Pen:
+                    if (!isDrawing) { return; }
+                    isDrawing = false;
+                    Capture = false;
+
+                    bool preferHorizontalFirst = PreferHorizontalFirst(drawingStart, e.Location);
+                    var trio = BuildOrthogonalPath(drawingStart, e.Location, preferHorizontalFirst);
+                    if (trio != null)
+                    {
+                        segments.Add(trio);
+                    }
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    isErasing = false;
+                    Capture = false;
+                    break;
+                case ToolType.Pointer:
+                    EndPointerDrag();
+                    break;
             }
-            Invalidate();
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -72,14 +167,29 @@ namespace LEARN_alpha
                     DrawOrthogonal(g, pen, s);
                 }
 
-                // 드래그 중 미리보기
-                if (isDragging)
+                foreach (var gate in gates)
                 {
-                    bool preferHorizontalFirst = PreferHorizontalFirst(start, current);
-                    var trio = BuildOrthogonalPath(start, current, preferHorizontalFirst);
+                    g.DrawImage(gate.Image, gate.Bounds);
+                }
+
+                // 드래그 중 미리보기
+                if (isDrawing)
+                {
+                    bool preferHorizontalFirst = PreferHorizontalFirst(drawingStart, drawingCurrent);
+                    var trio = BuildOrthogonalPath(drawingStart, drawingCurrent, preferHorizontalFirst);
                     if (trio != null)
                     {
                         DrawOrthogonal(g, previewPen, trio);
+                    }
+                }
+
+                if (gatePreviewLocation.HasValue && IsGateTool(currentTool))
+                {
+                    var img = GetGateImage(currentTool);
+                    if (img != null)
+                    {
+                        var aligned = AlignGateLocation(gatePreviewLocation.Value, img.Size);
+                        DrawGatePreview(g, img, aligned);
                     }
                 }
             }
@@ -95,6 +205,328 @@ namespace LEARN_alpha
             else
             {
                 g.DrawLines(pen, pts);
+            }
+        }
+
+        private void InitializeTools()
+        {
+            toolButtons.Clear();
+            toolButtons[ToolType.Pointer] = pointerButton;
+            toolButtons[ToolType.Pen] = penButton;
+            toolButtons[ToolType.Eraser] = eraserButton;
+            toolButtons[ToolType.GateAnd] = andGateButton;
+            toolButtons[ToolType.GateOr] = orGateButton;
+            toolButtons[ToolType.GateNot] = notGateButton;
+            toolButtons[ToolType.GateXor] = xorGateButton;
+
+            foreach (var pair in toolButtons)
+            {
+                var button = pair.Value;
+                button.Tag = pair.Key;
+                button.FlatStyle = FlatStyle.Flat;
+                button.FlatAppearance.BorderSize = 0;
+                button.Margin = new Padding(3);
+                button.Click += OnToolButtonClick;
+            }
+
+            SetCurrentTool(ToolType.Pointer);
+        }
+
+        private void OnToolButtonClick(object? sender, EventArgs e)
+        {
+            if (sender is Button button && button.Tag is ToolType tool)
+            {
+                SetCurrentTool(tool);
+            }
+        }
+
+        private void SetCurrentTool(ToolType tool)
+        {
+            currentTool = tool;
+            foreach (var pair in toolButtons)
+            {
+                pair.Value.BackColor = pair.Key == currentTool ? Color.FromArgb(210, 230, 255) : SystemColors.ControlLight;
+            }
+
+            isDrawing = false;
+            isErasing = false;
+            gatePreviewLocation = null;
+            ResetPointerState();
+            Capture = false;
+            Invalidate();
+        }
+
+        private void ResetPointerState()
+        {
+            pointerGateSelection = null;
+            pointerSegmentIndex = -1;
+            pointerSegmentOriginal = null;
+            pointerGateOffset = Size.Empty;
+            pointerDragStart = Point.Empty;
+        }
+
+        private void BeginPointerDrag(Point location)
+        {
+            ResetPointerState();
+
+            pointerGateSelection = HitTestGate(location);
+            if (pointerGateSelection != null)
+            {
+                pointerGateOffset = new Size(location.X - pointerGateSelection.Location.X, location.Y - pointerGateSelection.Location.Y);
+                pointerDragStart = location;
+                Capture = true;
+                return;
+            }
+
+            pointerSegmentIndex = FindSegmentIndex(location);
+            if (pointerSegmentIndex >= 0)
+            {
+                pointerSegmentOriginal = segments[pointerSegmentIndex].Select(p => p).ToArray();
+                pointerDragStart = location;
+                Capture = true;
+            }
+        }
+
+        private void UpdatePointerDrag(Point location)
+        {
+            if (pointerGateSelection != null)
+            {
+                pointerGateSelection.Location = new Point(location.X - pointerGateOffset.Width, location.Y - pointerGateOffset.Height);
+                Invalidate();
+                return;
+            }
+
+            if (pointerSegmentIndex >= 0 && pointerSegmentOriginal != null)
+            {
+                int dx = location.X - pointerDragStart.X;
+                int dy = location.Y - pointerDragStart.Y;
+                var updated = pointerSegmentOriginal.Select(p => new Point(p.X + dx, p.Y + dy)).ToArray();
+                segments[pointerSegmentIndex] = updated;
+                Invalidate();
+            }
+        }
+
+        private void EndPointerDrag()
+        {
+            if (pointerGateSelection != null || pointerSegmentIndex >= 0)
+            {
+                Capture = false;
+            }
+
+            ResetPointerState();
+        }
+
+        private void PlaceGate(Point location)
+        {
+            if (!IsGateTool(currentTool))
+            {
+                return;
+            }
+
+            var image = GetGateImage(currentTool);
+            var aligned = AlignGateLocation(location, image.Size);
+            gates.Add(new GateElement(currentTool, image, aligned));
+            gatePreviewLocation = location;
+            Invalidate();
+        }
+
+        private void DrawGatePreview(Graphics g, Image image, Point location)
+        {
+            using var attrs = new ImageAttributes();
+            var matrix = new ColorMatrix
+            {
+                Matrix33 = 0.5f
+            };
+            attrs.SetColorMatrix(matrix);
+
+            var destination = new Rectangle(location, image.Size);
+            g.DrawImage(image, destination, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
+        }
+
+        private static Point AlignGateLocation(Point cursor, Size size)
+        {
+            return new Point(cursor.X - size.Width / 2, cursor.Y - size.Height / 2);
+        }
+
+        private static bool IsGateTool(ToolType tool)
+        {
+            return tool == ToolType.GateAnd || tool == ToolType.GateOr || tool == ToolType.GateNot || tool == ToolType.GateXor;
+        }
+
+        private Bitmap GetGateImage(ToolType tool)
+        {
+            if (!IsGateTool(tool))
+            {
+                throw new ArgumentOutOfRangeException(nameof(tool), tool, null);
+            }
+
+            if (gateImages.TryGetValue(tool, out var cached))
+            {
+                return cached;
+            }
+
+            string name = tool switch
+            {
+                ToolType.GateAnd => "AND",
+                ToolType.GateOr => "OR",
+                ToolType.GateNot => "NOT",
+                ToolType.GateXor => "XOR",
+                _ => throw new ArgumentOutOfRangeException(nameof(tool), tool, null)
+            };
+
+            string assetsFolder = Path.Combine(AppContext.BaseDirectory, "Assets");
+            string filePath = Path.Combine(assetsFolder, $"{name}.png");
+
+            Bitmap image;
+            if (File.Exists(filePath))
+            {
+                image = new Bitmap(filePath);
+            }
+            else
+            {
+                Directory.CreateDirectory(assetsFolder);
+                image = CreateFallbackGateImage(name);
+                TrySaveFallback(image, filePath);
+            }
+
+            gateImages[tool] = image;
+            return image;
+        }
+
+        private static Bitmap CreateFallbackGateImage(string label)
+        {
+            var bitmap = new Bitmap(96, 64);
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.Clear(Color.White);
+                using var borderPen = new Pen(Color.Black, 2);
+                g.DrawRectangle(borderPen, 1, 1, bitmap.Width - 2, bitmap.Height - 2);
+
+                using var font = new Font(FontFamily.GenericSansSerif, 20, FontStyle.Bold, GraphicsUnit.Pixel);
+                var size = g.MeasureString(label, font);
+                float x = (bitmap.Width - size.Width) / 2f;
+                float y = (bitmap.Height - size.Height) / 2f;
+                g.DrawString(label, font, Brushes.Black, x, y);
+            }
+
+            return bitmap;
+        }
+
+        private static void TrySaveFallback(Bitmap bitmap, string path)
+        {
+            try
+            {
+                bitmap.Save(path);
+            }
+            catch
+            {
+                // 무시: 실행 환경에 따라 쓸 수 없는 경우가 있을 수 있다.
+            }
+        }
+
+        private GateElement? HitTestGate(Point location)
+        {
+            for (int i = gates.Count - 1; i >= 0; i--)
+            {
+                var gate = gates[i];
+                if (gate.Bounds.Contains(location))
+                {
+                    return gate;
+                }
+            }
+
+            return null;
+        }
+
+        private int FindSegmentIndex(Point location)
+        {
+            for (int i = segments.Count - 1; i >= 0; i--)
+            {
+                if (IsPointNearSegment(location, segments[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void EraseAt(Point location)
+        {
+            bool removed = false;
+
+            for (int i = segments.Count - 1; i >= 0; i--)
+            {
+                if (IsPointNearSegment(location, segments[i]))
+                {
+                    segments.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            for (int i = gates.Count - 1; i >= 0; i--)
+            {
+                if (gates[i].Bounds.Contains(location))
+                {
+                    gates.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            if (removed)
+            {
+                Invalidate();
+            }
+        }
+
+        private static bool IsPointNearSegment(Point point, Point[] segment)
+        {
+            if (segment.Length < 2)
+            {
+                return false;
+            }
+
+            const double threshold = 6.0;
+            for (int i = 0; i < segment.Length - 1; i++)
+            {
+                if (DistancePointToSegment(point, segment[i], segment[i + 1]) <= threshold)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static double DistancePointToSegment(Point point, Point a, Point b)
+        {
+            if (a == b)
+            {
+                return Distance(point, a);
+            }
+
+            double dx = b.X - a.X;
+            double dy = b.Y - a.Y;
+            double t = ((point.X - a.X) * dx + (point.Y - a.Y) * dy) / (dx * dx + dy * dy);
+            t = Math.Max(0, Math.Min(1, t));
+            double projX = a.X + t * dx;
+            double projY = a.Y + t * dy;
+            return Distance(point, new Point((int)Math.Round(projX), (int)Math.Round(projY)));
+        }
+
+        private static double Distance(Point a, Point b)
+        {
+            int dx = a.X - b.X;
+            int dy = a.Y - b.Y;
+            return Math.Sqrt(dx * dx + dy * dy);
+        }
+
+        private void OnMouseLeave(object? sender, EventArgs e)
+        {
+            if (IsGateTool(currentTool))
+            {
+                gatePreviewLocation = null;
+                Invalidate();
             }
         }
 


### PR DESCRIPTION
## Summary
- add a toolbar with pointer, pen, eraser, and logic gate buttons to control drawing modes
- implement tool behaviors including orthogonal pen drawing, erasing, gate previews/placement, and pointer-based repositioning
- support gate imagery by copying asset files to the build output and generating fallbacks when images are missing

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddee82c2d4832a8043f08583ef6fb1