### PR TITLE
Add snap hitboxes for attaching wires to gates

### DIFF
--- a/LEARN-alpha/LEARN-alpha.csproj
+++ b/LEARN-alpha/LEARN-alpha.csproj
@@ -9,4 +9,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="Assets\*.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/LEARN-alpha/Learn.Designer.cs
+++ b/LEARN-alpha/Learn.Designer.cs
@@ -28,14 +28,173 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
+            toolPanel = new FlowLayoutPanel();
+            pointerButton = new Button();
+            penButton = new Button();
+            eraserButton = new Button();
+            andGateButton = new Button();
+            orGateButton = new Button();
+            notGateButton = new Button();
+            xorGateButton = new Button();
+            nandGateButton = new Button();
+            norGateButton = new Button();
+            xnorGateButton = new Button();
+            toolPanel.SuspendLayout();
             SuspendLayout();
-            // 
+            //
+            // toolPanel
+            //
+            toolPanel.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            toolPanel.AutoSize = true;
+            toolPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            toolPanel.BackColor = Color.FromArgb(245, 245, 245);
+            toolPanel.Controls.Add(pointerButton);
+            toolPanel.Controls.Add(penButton);
+            toolPanel.Controls.Add(eraserButton);
+            toolPanel.Controls.Add(andGateButton);
+            toolPanel.Controls.Add(orGateButton);
+            toolPanel.Controls.Add(notGateButton);
+            toolPanel.Controls.Add(xorGateButton);
+            toolPanel.Controls.Add(nandGateButton);
+            toolPanel.Controls.Add(norGateButton);
+            toolPanel.Controls.Add(xnorGateButton);
+            toolPanel.FlowDirection = FlowDirection.LeftToRight;
+            toolPanel.Location = new Point(12, 12);
+            toolPanel.Margin = new Padding(4);
+            toolPanel.Name = "toolPanel";
+            toolPanel.Padding = new Padding(8, 6, 8, 6);
+            toolPanel.Size = new Size(961, 64);
+            toolPanel.TabIndex = 0;
+            toolPanel.WrapContents = false;
+            //
+            // pointerButton
+            //
+            pointerButton.BackColor = SystemColors.ControlLight;
+            pointerButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            pointerButton.Location = new Point(12, 9);
+            pointerButton.Margin = new Padding(4, 3, 4, 3);
+            pointerButton.Name = "pointerButton";
+            pointerButton.Size = new Size(90, 44);
+            pointerButton.TabIndex = 0;
+            pointerButton.Text = "포인터";
+            pointerButton.UseVisualStyleBackColor = false;
+            //
+            // penButton
+            //
+            penButton.BackColor = SystemColors.ControlLight;
+            penButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            penButton.Location = new Point(110, 9);
+            penButton.Margin = new Padding(4, 3, 4, 3);
+            penButton.Name = "penButton";
+            penButton.Size = new Size(90, 44);
+            penButton.TabIndex = 1;
+            penButton.Text = "펜";
+            penButton.UseVisualStyleBackColor = false;
+            //
+            // eraserButton
+            //
+            eraserButton.BackColor = SystemColors.ControlLight;
+            eraserButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            eraserButton.Location = new Point(208, 9);
+            eraserButton.Margin = new Padding(4, 3, 4, 3);
+            eraserButton.Name = "eraserButton";
+            eraserButton.Size = new Size(90, 44);
+            eraserButton.TabIndex = 2;
+            eraserButton.Text = "지우개";
+            eraserButton.UseVisualStyleBackColor = false;
+            //
+            // andGateButton
+            //
+            andGateButton.BackColor = SystemColors.ControlLight;
+            andGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            andGateButton.Location = new Point(306, 9);
+            andGateButton.Margin = new Padding(4, 3, 4, 3);
+            andGateButton.Name = "andGateButton";
+            andGateButton.Size = new Size(90, 44);
+            andGateButton.TabIndex = 3;
+            andGateButton.Text = "AND";
+            andGateButton.UseVisualStyleBackColor = false;
+            //
+            // orGateButton
+            //
+            orGateButton.BackColor = SystemColors.ControlLight;
+            orGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            orGateButton.Location = new Point(404, 9);
+            orGateButton.Margin = new Padding(4, 3, 4, 3);
+            orGateButton.Name = "orGateButton";
+            orGateButton.Size = new Size(90, 44);
+            orGateButton.TabIndex = 4;
+            orGateButton.Text = "OR";
+            orGateButton.UseVisualStyleBackColor = false;
+            //
+            // notGateButton
+            //
+            notGateButton.BackColor = SystemColors.ControlLight;
+            notGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            notGateButton.Location = new Point(502, 9);
+            notGateButton.Margin = new Padding(4, 3, 4, 3);
+            notGateButton.Name = "notGateButton";
+            notGateButton.Size = new Size(90, 44);
+            notGateButton.TabIndex = 5;
+            notGateButton.Text = "NOT";
+            notGateButton.UseVisualStyleBackColor = false;
+            //
+            // xorGateButton
+            //
+            xorGateButton.BackColor = SystemColors.ControlLight;
+            xorGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            xorGateButton.Location = new Point(600, 9);
+            xorGateButton.Margin = new Padding(4, 3, 4, 3);
+            xorGateButton.Name = "xorGateButton";
+            xorGateButton.Size = new Size(90, 44);
+            xorGateButton.TabIndex = 6;
+            xorGateButton.Text = "XOR";
+            xorGateButton.UseVisualStyleBackColor = false;
+            //
+            // nandGateButton
+            //
+            nandGateButton.BackColor = SystemColors.ControlLight;
+            nandGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            nandGateButton.Location = new Point(698, 9);
+            nandGateButton.Margin = new Padding(4, 3, 4, 3);
+            nandGateButton.Name = "nandGateButton";
+            nandGateButton.Size = new Size(90, 44);
+            nandGateButton.TabIndex = 7;
+            nandGateButton.Text = "NAND";
+            nandGateButton.UseVisualStyleBackColor = false;
+            //
+            // norGateButton
+            //
+            norGateButton.BackColor = SystemColors.ControlLight;
+            norGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            norGateButton.Location = new Point(796, 9);
+            norGateButton.Margin = new Padding(4, 3, 4, 3);
+            norGateButton.Name = "norGateButton";
+            norGateButton.Size = new Size(90, 44);
+            norGateButton.TabIndex = 8;
+            norGateButton.Text = "NOR";
+            norGateButton.UseVisualStyleBackColor = false;
+            //
+            // xnorGateButton
+            //
+            xnorGateButton.BackColor = SystemColors.ControlLight;
+            xnorGateButton.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            xnorGateButton.Location = new Point(894, 9);
+            xnorGateButton.Margin = new Padding(4, 3, 4, 3);
+            xnorGateButton.Name = "xnorGateButton";
+            xnorGateButton.Size = new Size(90, 44);
+            xnorGateButton.TabIndex = 9;
+            xnorGateButton.Text = "XNOR";
+            xnorGateButton.UseVisualStyleBackColor = false;
+            //
             // Learn
-            // 
+            //
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1063, 610);
+            Controls.Add(toolPanel);
             DoubleBuffered = true;
             KeyPreview = true;
             Name = "Learn";
@@ -44,9 +203,24 @@
             MouseDown += OnMouseDown;
             MouseMove += OnMouseMove;
             MouseUp += OnMouseUp;
+            MouseLeave += OnMouseLeave;
+            toolPanel.ResumeLayout(false);
             ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
+
+        private FlowLayoutPanel toolPanel;
+        private Button pointerButton;
+        private Button penButton;
+        private Button eraserButton;
+        private Button andGateButton;
+        private Button orGateButton;
+        private Button notGateButton;
+        private Button xorGateButton;
+        private Button nandGateButton;
+        private Button norGateButton;
+        private Button xnorGateButton;
     }
 }

--- a/LEARN-alpha/Learn.cs
+++ b/LEARN-alpha/Learn.cs
@@ -1,4 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace LEARN_alpha
 {
@@ -7,19 +14,158 @@ namespace LEARN_alpha
         public Learn()
         {
             InitializeComponent();
+            InitializeTools();
         }
 
-        private readonly List<Point[]> segments = new List<Point[]>();
-        private bool isDragging = false;
-        private Point start;
-        private Point current;
+        private enum ToolType
+        {
+            Pointer,
+            Pen,
+            Eraser,
+            GateAnd,
+            GateOr,
+            GateNot,
+            GateXor,
+            GateNand,
+            GateNor,
+            GateXnor
+        }
+
+        private const double GateScale = 0.5;
+
+        private sealed class GateElement
+        {
+            private Point location;
+
+            public ToolType Type { get; }
+            public Bitmap Image { get; }
+            public Size DisplaySize { get; }
+            public Rectangle Bounds => new Rectangle(Location, DisplaySize);
+
+            public IReadOnlyList<GateConnector> Connectors => connectors;
+
+            public Point Location
+            {
+                get => location;
+                set
+                {
+                    location = value;
+                    foreach (var connector in connectors)
+                    {
+                        connector.Refresh(location);
+                    }
+                }
+            }
+
+            private readonly GateConnector[] connectors;
+
+            public GateElement(ToolType type, Bitmap image, Point location, Size displaySize, IReadOnlyList<GateConnectorTemplate> connectorTemplates)
+            {
+                Type = type;
+                Image = image;
+                DisplaySize = displaySize;
+                connectors = connectorTemplates.Select(template => new GateConnector(template)).ToArray();
+                Location = location;
+            }
+        }
+
+        private sealed class GateConnectorTemplate
+        {
+            public GateConnectorTemplate(ConnectorRole role, Point relativeAnchor, Size hitSize)
+            {
+                Role = role;
+                RelativeAnchor = relativeAnchor;
+                HitSize = hitSize;
+            }
+
+            public ConnectorRole Role { get; }
+            public Point RelativeAnchor { get; }
+            public Size HitSize { get; }
+        }
+
+        private sealed class GateConnector
+        {
+            private readonly GateConnectorTemplate template;
+            private Rectangle bounds;
+            private Point anchor;
+
+            public GateConnector(GateConnectorTemplate template)
+            {
+                this.template = template;
+            }
+
+            public ConnectorRole Role => template.Role;
+
+            public Rectangle Bounds => bounds;
+
+            public Point Anchor => anchor;
+
+            public void Refresh(Point ownerLocation)
+            {
+                anchor = new Point(ownerLocation.X + template.RelativeAnchor.X, ownerLocation.Y + template.RelativeAnchor.Y);
+                bounds = new Rectangle(anchor.X - template.HitSize.Width / 2, anchor.Y - template.HitSize.Height / 2, template.HitSize.Width, template.HitSize.Height);
+            }
+        }
+
+        private sealed class WireSegment
+        {
+            public WireSegment(Point[] points)
+            {
+                Points = points;
+            }
+
+            public Point[] Points { get; set; }
+            public WireAttachment? StartAttachment { get; set; }
+            public WireAttachment? EndAttachment { get; set; }
+        }
+
+        private sealed class WireAttachment
+        {
+            public WireAttachment(GateElement gate, GateConnector connector)
+            {
+                Gate = gate;
+                Connector = connector;
+            }
+
+            public GateElement Gate { get; }
+            public GateConnector Connector { get; }
+        }
+
+        private enum ConnectorRole
+        {
+            Input,
+            Output
+        }
+
+        private readonly List<WireSegment> wires = new List<WireSegment>();
+        private readonly List<GateElement> gates = new List<GateElement>();
+        private readonly Dictionary<ToolType, Bitmap> gateImages = new Dictionary<ToolType, Bitmap>();
+        private readonly Dictionary<ToolType, Button> toolButtons = new Dictionary<ToolType, Button>();
+
+        private ToolType currentTool = ToolType.Pointer;
+
+        private bool isDrawing = false;
+        private bool isErasing = false;
+        private Point drawingStart;
+        private Point drawingCurrent;
+
+        private GateElement? pointerGateSelection;
+        private Size pointerGateOffset;
+        private int pointerWireIndex = -1;
+        private Point[]? pointerWireOriginal;
+        private Point pointerDragStart;
+
+        private Point? gatePreviewLocation;
 
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             // C 키로 지우기
             if (e.KeyCode == Keys.C)
             {
-                segments.Clear();
+                wires.Clear();
+                gates.Clear();
+                ResetPointerState();
+                gatePreviewLocation = null;
                 Invalidate();
             }
         }
@@ -27,34 +173,82 @@ namespace LEARN_alpha
         private void OnMouseDown(object sender, MouseEventArgs e)
         {
             if (e.Button != MouseButtons.Left) { return; }
-            isDragging = true;
-            start = e.Location;
-            current = e.Location;
-            Capture = true;
-            Invalidate();
+
+            switch (currentTool)
+            {
+                case ToolType.Pen:
+                    isDrawing = true;
+                    drawingStart = e.Location;
+                    drawingCurrent = e.Location;
+                    Capture = true;
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    isErasing = true;
+                    EraseAt(e.Location);
+                    Capture = true;
+                    break;
+                case ToolType.Pointer:
+                    BeginPointerDrag(e.Location);
+                    break;
+                default:
+                    PlaceGate(e.Location);
+                    break;
+            }
         }
 
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
-            if (!isDragging) { return; }
-            current = e.Location;
-            Invalidate();
+            switch (currentTool)
+            {
+                case ToolType.Pen:
+                    if (!isDrawing) { return; }
+                    drawingCurrent = e.Location;
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    if (!isErasing) { return; }
+                    EraseAt(e.Location);
+                    break;
+                case ToolType.Pointer:
+                    UpdatePointerDrag(e.Location);
+                    break;
+                default:
+                    gatePreviewLocation = e.Location;
+                    Invalidate();
+                    break;
+            }
         }
 
         private void OnMouseUp(object sender, MouseEventArgs e)
         {
-            if (!isDragging || e.Button != MouseButtons.Left) { return; }
-            isDragging = false;
-            Capture = false;
+            if (e.Button != MouseButtons.Left) { return; }
 
-            bool preferHorizontalFirst = PreferHorizontalFirst(start, e.Location);
-
-            var trio = BuildOrthogonalPath(start, e.Location, preferHorizontalFirst);
-            if (trio != null)
+            switch (currentTool)
             {
-                segments.Add(trio);
+                case ToolType.Pen:
+                    if (!isDrawing) { return; }
+                    isDrawing = false;
+                    Capture = false;
+
+                    bool preferHorizontalFirst = PreferHorizontalFirst(drawingStart, e.Location);
+                    var trio = BuildOrthogonalPath(drawingStart, e.Location, preferHorizontalFirst);
+                    if (trio != null)
+                    {
+                        var wire = new WireSegment(trio);
+                        SnapWireAttachments(wire);
+                        wires.Add(wire);
+                    }
+                    Invalidate();
+                    break;
+                case ToolType.Eraser:
+                    isErasing = false;
+                    Capture = false;
+                    break;
+                case ToolType.Pointer:
+                    EndPointerDrag();
+                    break;
             }
-            Invalidate();
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -67,19 +261,35 @@ namespace LEARN_alpha
             using (var previewPen = new Pen(Color.Gray, 1) { DashStyle = DashStyle.Dash })
             {
                 // 확정된 선들
-                foreach (var s in segments)
+                foreach (var wire in wires)
                 {
-                    DrawOrthogonal(g, pen, s);
+                    DrawOrthogonal(g, pen, wire.Points);
+                }
+
+                foreach (var gate in gates)
+                {
+                    g.DrawImage(gate.Image, gate.Bounds);
                 }
 
                 // 드래그 중 미리보기
-                if (isDragging)
+                if (isDrawing)
                 {
-                    bool preferHorizontalFirst = PreferHorizontalFirst(start, current);
-                    var trio = BuildOrthogonalPath(start, current, preferHorizontalFirst);
+                    bool preferHorizontalFirst = PreferHorizontalFirst(drawingStart, drawingCurrent);
+                    var trio = BuildOrthogonalPath(drawingStart, drawingCurrent, preferHorizontalFirst);
                     if (trio != null)
                     {
                         DrawOrthogonal(g, previewPen, trio);
+                    }
+                }
+
+                if (gatePreviewLocation.HasValue && IsGateTool(currentTool))
+                {
+                    var img = GetGateImage(currentTool);
+                    if (img != null)
+                    {
+                        var size = GetGateDisplaySize(img);
+                        var aligned = AlignGateLocation(gatePreviewLocation.Value, size);
+                        DrawGatePreview(g, img, aligned, size);
                     }
                 }
             }
@@ -95,6 +305,567 @@ namespace LEARN_alpha
             else
             {
                 g.DrawLines(pen, pts);
+            }
+        }
+
+        private void InitializeTools()
+        {
+            toolButtons.Clear();
+            toolButtons[ToolType.Pointer] = pointerButton;
+            toolButtons[ToolType.Pen] = penButton;
+            toolButtons[ToolType.Eraser] = eraserButton;
+            toolButtons[ToolType.GateAnd] = andGateButton;
+            toolButtons[ToolType.GateOr] = orGateButton;
+            toolButtons[ToolType.GateNot] = notGateButton;
+            toolButtons[ToolType.GateXor] = xorGateButton;
+            toolButtons[ToolType.GateNand] = nandGateButton;
+            toolButtons[ToolType.GateNor] = norGateButton;
+            toolButtons[ToolType.GateXnor] = xnorGateButton;
+
+            foreach (var pair in toolButtons)
+            {
+                var button = pair.Value;
+                button.Tag = pair.Key;
+                button.FlatStyle = FlatStyle.Flat;
+                button.FlatAppearance.BorderSize = 0;
+                button.Margin = new Padding(3);
+                button.Click += OnToolButtonClick;
+            }
+
+            SetCurrentTool(ToolType.Pointer);
+        }
+
+        private void OnToolButtonClick(object? sender, EventArgs e)
+        {
+            if (sender is Button button && button.Tag is ToolType tool)
+            {
+                SetCurrentTool(tool);
+            }
+        }
+
+        private void SetCurrentTool(ToolType tool)
+        {
+            currentTool = tool;
+            foreach (var pair in toolButtons)
+            {
+                pair.Value.BackColor = pair.Key == currentTool ? Color.FromArgb(210, 230, 255) : SystemColors.ControlLight;
+            }
+
+            isDrawing = false;
+            isErasing = false;
+            gatePreviewLocation = null;
+            ResetPointerState();
+            Capture = false;
+            Invalidate();
+        }
+
+        private void ResetPointerState()
+        {
+            pointerGateSelection = null;
+            pointerWireIndex = -1;
+            pointerWireOriginal = null;
+            pointerGateOffset = Size.Empty;
+            pointerDragStart = Point.Empty;
+        }
+
+        private void BeginPointerDrag(Point location)
+        {
+            ResetPointerState();
+
+            pointerGateSelection = HitTestGate(location);
+            if (pointerGateSelection != null)
+            {
+                pointerGateOffset = new Size(location.X - pointerGateSelection.Location.X, location.Y - pointerGateSelection.Location.Y);
+                pointerDragStart = location;
+                Capture = true;
+                return;
+            }
+
+            pointerWireIndex = FindWireIndex(location);
+            if (pointerWireIndex >= 0)
+            {
+                pointerWireOriginal = wires[pointerWireIndex].Points.Select(p => p).ToArray();
+                wires[pointerWireIndex].StartAttachment = null;
+                wires[pointerWireIndex].EndAttachment = null;
+                pointerDragStart = location;
+                Capture = true;
+            }
+        }
+
+        private void UpdatePointerDrag(Point location)
+        {
+            if (pointerGateSelection != null)
+            {
+                pointerGateSelection.Location = new Point(location.X - pointerGateOffset.Width, location.Y - pointerGateOffset.Height);
+                RefreshAttachmentsForGate(pointerGateSelection);
+                Invalidate();
+                return;
+            }
+
+            if (pointerWireIndex >= 0 && pointerWireOriginal != null)
+            {
+                int dx = location.X - pointerDragStart.X;
+                int dy = location.Y - pointerDragStart.Y;
+                var updated = pointerWireOriginal.Select(p => new Point(p.X + dx, p.Y + dy)).ToArray();
+                wires[pointerWireIndex].Points = updated;
+                Invalidate();
+            }
+        }
+
+        private void EndPointerDrag()
+        {
+            if (pointerGateSelection != null)
+            {
+                Capture = false;
+                RefreshAttachmentsForGate(pointerGateSelection);
+                Invalidate();
+            }
+            else if (pointerWireIndex >= 0)
+            {
+                Capture = false;
+                if (pointerWireIndex >= 0 && pointerWireIndex < wires.Count)
+                {
+                    var wire = wires[pointerWireIndex];
+                    SnapWireAttachments(wire);
+                }
+                Invalidate();
+            }
+
+            ResetPointerState();
+        }
+
+        private void PlaceGate(Point location)
+        {
+            if (!IsGateTool(currentTool))
+            {
+                return;
+            }
+
+            var image = GetGateImage(currentTool);
+            var size = GetGateDisplaySize(image);
+            var aligned = AlignGateLocation(location, size);
+            var gate = CreateGateElement(currentTool, image, aligned, size);
+            gates.Add(gate);
+            foreach (var wire in wires)
+            {
+                SnapWireAttachments(wire);
+            }
+            gatePreviewLocation = location;
+            Invalidate();
+        }
+
+        private void DrawGatePreview(Graphics g, Image image, Point location, Size size)
+        {
+            using var attrs = new ImageAttributes();
+            var matrix = new ColorMatrix
+            {
+                Matrix33 = 0.5f
+            };
+            attrs.SetColorMatrix(matrix);
+
+            var destination = new Rectangle(location, size);
+            g.DrawImage(image, destination, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
+        }
+
+        private static Point AlignGateLocation(Point cursor, Size size)
+        {
+            return new Point(cursor.X - size.Width / 2, cursor.Y - size.Height / 2);
+        }
+
+        private GateElement CreateGateElement(ToolType tool, Bitmap image, Point location, Size displaySize)
+        {
+            var templates = BuildGateConnectorTemplates(tool, displaySize);
+            return new GateElement(tool, image, location, displaySize, templates);
+        }
+
+        private static IReadOnlyList<GateConnectorTemplate> BuildGateConnectorTemplates(ToolType tool, Size displaySize)
+        {
+            int hitSize = Math.Max(12, Math.Min(displaySize.Width, displaySize.Height) / 4);
+            int margin = Math.Max(4, (int)Math.Round(displaySize.Width * 0.1));
+            margin = Math.Min(margin, displaySize.Width / 2);
+            int leftX = margin;
+            int rightX = Math.Max(margin, displaySize.Width - margin);
+            int midY = displaySize.Height / 2;
+
+            var connectors = new List<GateConnectorTemplate>();
+
+            if (tool == ToolType.GateNot)
+            {
+                connectors.Add(new GateConnectorTemplate(ConnectorRole.Input, new Point(leftX, midY), new Size(hitSize, hitSize)));
+                connectors.Add(new GateConnectorTemplate(ConnectorRole.Output, new Point(rightX, midY), new Size(hitSize, hitSize)));
+                return connectors;
+            }
+
+            int topY = (int)Math.Round(displaySize.Height * 0.35);
+            int bottomY = (int)Math.Round(displaySize.Height * 0.65);
+
+            connectors.Add(new GateConnectorTemplate(ConnectorRole.Input, new Point(leftX, topY), new Size(hitSize, hitSize)));
+            connectors.Add(new GateConnectorTemplate(ConnectorRole.Input, new Point(leftX, bottomY), new Size(hitSize, hitSize)));
+            connectors.Add(new GateConnectorTemplate(ConnectorRole.Output, new Point(rightX, midY), new Size(hitSize, hitSize)));
+            return connectors;
+        }
+
+        private static bool IsGateTool(ToolType tool)
+        {
+            return tool == ToolType.GateAnd
+                || tool == ToolType.GateOr
+                || tool == ToolType.GateNot
+                || tool == ToolType.GateXor
+                || tool == ToolType.GateNand
+                || tool == ToolType.GateNor
+                || tool == ToolType.GateXnor;
+        }
+
+        private Bitmap GetGateImage(ToolType tool)
+        {
+            if (!IsGateTool(tool))
+            {
+                throw new ArgumentOutOfRangeException(nameof(tool), tool, null);
+            }
+
+            if (gateImages.TryGetValue(tool, out var cached))
+            {
+                return cached;
+            }
+
+            string name = tool switch
+            {
+                ToolType.GateAnd => "AND",
+                ToolType.GateOr => "OR",
+                ToolType.GateNot => "NOT",
+                ToolType.GateXor => "XOR",
+                ToolType.GateNand => "NAND",
+                ToolType.GateNor => "NOR",
+                ToolType.GateXnor => "XNOR",
+                _ => throw new ArgumentOutOfRangeException(nameof(tool), tool, null)
+            };
+
+            string baseDirectory = AppContext.BaseDirectory;
+            string primaryPath = Path.Combine(baseDirectory, $"{name}.png");
+
+            Bitmap? image = LoadBitmapIfExists(primaryPath);
+            if (image == null)
+            {
+                string assetsFolder = Path.Combine(baseDirectory, "Assets");
+                string assetsPath = Path.Combine(assetsFolder, $"{name}.png");
+
+                image = LoadBitmapIfExists(assetsPath);
+                if (image == null)
+                {
+                    Directory.CreateDirectory(assetsFolder);
+                    image = CreateFallbackGateImage(name);
+                    TrySaveFallback(image, assetsPath);
+                }
+            }
+
+            gateImages[tool] = image;
+            return image;
+        }
+
+        private static Size GetGateDisplaySize(Image image)
+        {
+            int width = Math.Max(1, (int)Math.Round(image.Width * GateScale));
+            int height = Math.Max(1, (int)Math.Round(image.Height * GateScale));
+            return new Size(width, height);
+        }
+
+        private (GateElement gate, GateConnector connector)? FindConnectorHit(Point location)
+        {
+            for (int i = gates.Count - 1; i >= 0; i--)
+            {
+                var gate = gates[i];
+                foreach (var connector in gate.Connectors)
+                {
+                    if (connector.Bounds.Contains(location))
+                    {
+                        return (gate, connector);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private void SnapWireAttachments(WireSegment wire)
+        {
+            if (wire.Points == null || wire.Points.Length == 0)
+            {
+                wire.StartAttachment = null;
+                wire.EndAttachment = null;
+                return;
+            }
+
+            var startHit = FindConnectorHit(wire.Points[0]);
+            if (startHit.HasValue)
+            {
+                wire.StartAttachment = new WireAttachment(startHit.Value.gate, startHit.Value.connector);
+                ApplyStartAttachment(wire);
+            }
+            else
+            {
+                wire.StartAttachment = null;
+            }
+
+            int lastIndex = wire.Points.Length - 1;
+            var endHit = FindConnectorHit(wire.Points[lastIndex]);
+            if (endHit.HasValue)
+            {
+                wire.EndAttachment = new WireAttachment(endHit.Value.gate, endHit.Value.connector);
+                ApplyEndAttachment(wire);
+            }
+            else
+            {
+                wire.EndAttachment = null;
+            }
+        }
+
+        private static void ApplyStartAttachment(WireSegment wire)
+        {
+            if (wire.StartAttachment == null)
+            {
+                return;
+            }
+
+            Point anchor = wire.StartAttachment.Connector.Anchor;
+            if (wire.Points.Length == 0)
+            {
+                wire.Points = new[] { anchor };
+                return;
+            }
+
+            wire.Points[0] = anchor;
+
+            if (wire.Points.Length >= 2)
+            {
+                Point next = wire.Points[1];
+                if (Math.Abs(next.X - anchor.X) <= Math.Abs(next.Y - anchor.Y))
+                {
+                    wire.Points[1] = new Point(anchor.X, next.Y);
+                }
+                else
+                {
+                    wire.Points[1] = new Point(next.X, anchor.Y);
+                }
+            }
+        }
+
+        private static void ApplyEndAttachment(WireSegment wire)
+        {
+            if (wire.EndAttachment == null)
+            {
+                return;
+            }
+
+            Point anchor = wire.EndAttachment.Connector.Anchor;
+            if (wire.Points.Length == 0)
+            {
+                wire.Points = new[] { anchor };
+                return;
+            }
+
+            int lastIndex = wire.Points.Length - 1;
+            wire.Points[lastIndex] = anchor;
+
+            if (wire.Points.Length >= 2)
+            {
+                int beforeIndex = lastIndex - 1;
+                Point previous = wire.Points[beforeIndex];
+                if (Math.Abs(previous.X - anchor.X) <= Math.Abs(previous.Y - anchor.Y))
+                {
+                    wire.Points[beforeIndex] = new Point(anchor.X, previous.Y);
+                }
+                else
+                {
+                    wire.Points[beforeIndex] = new Point(previous.X, anchor.Y);
+                }
+            }
+        }
+
+        private void RefreshAttachmentsForGate(GateElement gate)
+        {
+            foreach (var wire in wires)
+            {
+                if (wire.StartAttachment != null && wire.StartAttachment.Gate == gate)
+                {
+                    ApplyStartAttachment(wire);
+                }
+
+                if (wire.EndAttachment != null && wire.EndAttachment.Gate == gate)
+                {
+                    ApplyEndAttachment(wire);
+                }
+            }
+        }
+
+        private void RemoveAttachmentsForGate(GateElement gate)
+        {
+            foreach (var wire in wires)
+            {
+                if (wire.StartAttachment != null && wire.StartAttachment.Gate == gate)
+                {
+                    wire.StartAttachment = null;
+                }
+
+                if (wire.EndAttachment != null && wire.EndAttachment.Gate == gate)
+                {
+                    wire.EndAttachment = null;
+                }
+            }
+        }
+
+        private static Bitmap? LoadBitmapIfExists(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            try
+            {
+                return new Bitmap(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Bitmap CreateFallbackGateImage(string label)
+        {
+            var bitmap = new Bitmap(96, 64);
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.Clear(Color.White);
+                using var borderPen = new Pen(Color.Black, 2);
+                g.DrawRectangle(borderPen, 1, 1, bitmap.Width - 2, bitmap.Height - 2);
+
+                using var font = new Font(FontFamily.GenericSansSerif, 20, FontStyle.Bold, GraphicsUnit.Pixel);
+                var size = g.MeasureString(label, font);
+                float x = (bitmap.Width - size.Width) / 2f;
+                float y = (bitmap.Height - size.Height) / 2f;
+                g.DrawString(label, font, Brushes.Black, x, y);
+            }
+
+            return bitmap;
+        }
+
+        private static void TrySaveFallback(Bitmap bitmap, string path)
+        {
+            try
+            {
+                bitmap.Save(path);
+            }
+            catch
+            {
+                // 무시: 실행 환경에 따라 쓸 수 없는 경우가 있을 수 있다.
+            }
+        }
+
+        private GateElement? HitTestGate(Point location)
+        {
+            for (int i = gates.Count - 1; i >= 0; i--)
+            {
+                var gate = gates[i];
+                if (gate.Bounds.Contains(location))
+                {
+                    return gate;
+                }
+            }
+
+            return null;
+        }
+
+        private int FindWireIndex(Point location)
+        {
+            for (int i = wires.Count - 1; i >= 0; i--)
+            {
+                if (IsPointNearSegment(location, wires[i].Points))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void EraseAt(Point location)
+        {
+            bool removed = false;
+
+            for (int i = wires.Count - 1; i >= 0; i--)
+            {
+                if (IsPointNearSegment(location, wires[i].Points))
+                {
+                    wires.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            for (int i = gates.Count - 1; i >= 0; i--)
+            {
+                var gate = gates[i];
+                if (gate.Bounds.Contains(location))
+                {
+                    RemoveAttachmentsForGate(gate);
+                    gates.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            if (removed)
+            {
+                Invalidate();
+            }
+        }
+
+        private static bool IsPointNearSegment(Point point, Point[] segment)
+        {
+            if (segment.Length < 2)
+            {
+                return false;
+            }
+
+            const double threshold = 6.0;
+            for (int i = 0; i < segment.Length - 1; i++)
+            {
+                if (DistancePointToSegment(point, segment[i], segment[i + 1]) <= threshold)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static double DistancePointToSegment(Point point, Point a, Point b)
+        {
+            if (a == b)
+            {
+                return Distance(point, a);
+            }
+
+            double dx = b.X - a.X;
+            double dy = b.Y - a.Y;
+            double t = ((point.X - a.X) * dx + (point.Y - a.Y) * dy) / (dx * dx + dy * dy);
+            t = Math.Max(0, Math.Min(1, t));
+            double projX = a.X + t * dx;
+            double projY = a.Y + t * dy;
+            return Distance(point, new Point((int)Math.Round(projX), (int)Math.Round(projY)));
+        }
+
+        private static double Distance(Point a, Point b)
+        {
+            int dx = a.X - b.X;
+            int dy = a.Y - b.Y;
+            return Math.Sqrt(dx * dx + dy * dy);
+        }
+
+        private void OnMouseLeave(object? sender, EventArgs e)
+        {
+            if (IsGateTool(currentTool))
+            {
+                gatePreviewLocation = null;
+                Invalidate();
             }
         }
 


### PR DESCRIPTION
## Summary
- add toolbar buttons for NAND, NOR, and XNOR gates alongside existing drawing tools
- extend gate tool handling to load images, previews, and placement for the new gate types at 50% scale
- create snap hitboxes for each gate connector so wires attach during drawing, movement, and deletion

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddee82c2d4832a8043f08583ef6fb1